### PR TITLE
Support Properties links (frontmatter links) added in Obsidian 1.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tsconfig/svelte": "^2.0.1",
     "@types/node": "^14.17.9",
     "husky": "^7.0.0",
-    "obsidian": "^1.2.8",
+    "obsidian": "^1.4.0",
     "prettier": "^2.5.0",
     "prettier-plugin-svelte": "^2.5.0",
     "pretty-quick": "^3.1.2",

--- a/src/db.ts
+++ b/src/db.ts
@@ -4,7 +4,13 @@ import {
   LINKED_TO,
   LINKED_FROM,
 } from "./constants";
-import type { App, Vault, LinkCache, EmbedCache } from "obsidian";
+import type {
+  App,
+  Vault,
+  LinkCache,
+  EmbedCache,
+  FrontmatterLinkCache,
+} from "obsidian";
 import { Notice } from "obsidian";
 import { FileItem, DB, Path } from "./types";
 import { FileNameFromPath } from "./utils";
@@ -202,7 +208,7 @@ export class DBManager {
         note.path
       ).frontmatterLinks;
       if (frontmatter_linkcache) {
-        frontmatter_linkcache.forEach((val: LinkCache) => {
+        frontmatter_linkcache.forEach((val: FrontmatterLinkCache) => {
           all_links.push(val.link);
         });
       }

--- a/src/db.ts
+++ b/src/db.ts
@@ -197,6 +197,16 @@ export class DBManager {
           all_links.push(val.link);
         });
       }
+
+      let frontmatter_linkcache = this.app.metadataCache.getCache(
+        note.path
+      ).frontmatterLinks;
+      if (frontmatter_linkcache) {
+        frontmatter_linkcache.forEach((val: LinkCache) => {
+          all_links.push(val.link);
+        });
+      }
+
       all_links.forEach((link: string) => {
         // remove references to blocks or sections
         link = link.split("#")[0];


### PR DESCRIPTION
## Changes

- Considers links in the frontmatter when determining route to central note
- Updates minimum Obsidian API version to 1.4.0 (when the `frontmatterLinks` property was added)

## Context

The new [Obsidian 1.4.5](https://obsidian.md/changelog/2023-08-31-desktop-v1.4.5/) release added a new feature called Properties. One of the things it does is add support wiki-style links (e.g. `[[]]`) in the yaml frontmatter. These links are not added to the `.links` property in `CachedMetadata`. Instead they are added as a new and separate property called `.frontmatterLinks`.

I think that the code for building the list of links could probably get tidied a little bit by using  a `Set` instead of an array for `all_links` since it would naturally handle the de-duplication safety check, but I didn't want to exceed the scope of the problem, which is just to get frontmatter links into `all_links`.

## Testing

You can test this out by doing the following.

Verify that frontmatter links **are not** considered without this patch:

1. Update to Obsidian 1.4.5
2. Make sure there is a central note set in the Map of Content plugin settings
3. Create a new note
4. Add a property to the new note and add a link to the central note
5. On the new note, the Map of Content viewer should show no connections to the central note

Verify that frontmatter links **are** considered with this patch:

1. Update to Obsidian 1.4.5
2. Update the Map of Content plugin to use this branch
3. Create a new note
4. Add a property to the new note and add a link to the central note
5. On the new note, the Map of Content viewer should the connections to the central note

## Note about the API

The new property is visible in the Obsidian Developer Console, even if it isn't yet documented in the [web API docs](https://docs.obsidian.md/Reference/TypeScript+API/CachedMetadata/CachedMetadata). Here are some screenshots of what is currently shown in the API docs (apparently incorrect or incomplete) and what you can see in the Obsidian Developer Console.

![Screenshot from 2023-09-02 11-00-12](https://github.com/Robin-Haupt-1/Obsidian-Map-of-Content/assets/67701/d1568322-79a6-4734-8c57-3b4dedf5cc0e)
![Screenshot from 2023-09-02 11-01-41](https://github.com/Robin-Haupt-1/Obsidian-Map-of-Content/assets/67701/aafa3b2e-08eb-45ab-9933-f395577e81d2)
